### PR TITLE
Tweak authUser to default empty roles without blowing up

### DIFF
--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -72,17 +72,13 @@ class Firebase {
           .then(snapshot => {
             const dbUser = snapshot.data();
 
-            // default empty roles
-            if (!dbUser.roles) {
-              dbUser.roles = [];
-            }
-
             // merge auth and db user
             authUser = {
               uid: authUser.uid,
               email: authUser.email,
               emailVerified: authUser.emailVerified,
               providerData: authUser.providerData,
+              roles: [],
               ...dbUser,
             };
 


### PR DESCRIPTION
I've been messing about trying to combine `react-redux-firebase-authentication` with this `react-firestore-authentication`as I want to use both Redux and Firestore.

I've managed to do so by looking at the diffs in this repo, but one part kept erroring out.

For some reason my `snapshot` was returning without a data child, so line `if (!dbUser.roles) {...}` was erroring out as `dbUser` was returning undefined.

I'm not sure if this is due to my setup being fresh, or wrong. But it seems to me this setup of setting the default `roles` in `authUser` and letting `dbUser` overwrite that if it has any is cleaner, as well as solving my problem.

I don't have a good grasp of the codebase here, so feel free to reject, but just submitting as it might help some folks.