### PR TITLE
timestampsInSnapshots: true is now the default in firestore

### DIFF
--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -24,7 +24,6 @@ class Firebase {
 
     this.auth = app.auth();
     this.db = app.firestore();
-    this.db.settings({ timestampsInSnapshots: true });
 
     /* Social Sign In Method Provider */
 


### PR DESCRIPTION
Hi Robin,

as you wish, PR right here... :)

Changelog:
https://github.com/firebase/firebase-js-sdk/blob/3c5338699e1e83a200a6e976d286e2031073db7f/packages/firestore/CHANGELOG.md#100

fixing https://github.com/the-road-to-react-with-firebase/react-firestore-authentication/issues/11